### PR TITLE
Feat/multithreading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(
     
     # Sources
     ${CMAKE_CURRENT_SOURCE_DIR}/fake_receiver.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/can_handler.cpp  
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/can_handler.cpp
+++ b/can_handler.cpp
@@ -51,7 +51,7 @@ void CanHandler::receiveLoop() {
         int bytes_read = can_receive(buffer);
 
         if (bytes_read > 0){
-            string msg(buffer);
+            string msg(buffer, bytes_read);
             // cout << "Received CAN message: " << msg << endl;
             lock_guard<mutex> lock(m_mutex);   // Lock the mutex to safely access the message queue
             m_messageQueue.push(msg); // Add the received message to the queue

--- a/can_handler.cpp
+++ b/can_handler.cpp
@@ -1,0 +1,76 @@
+#include "can_handler.h"
+#include <iostream>
+
+using namespace std;
+
+CanHandler::CanHandler(const string& filepath) { // Constructor: initialize the CAN handler with the given file path
+    m_filepath = filepath;
+    m_running = false;
+}
+
+CanHandler::~CanHandler() { // Destructor: clean up resources
+    stop();
+}
+
+bool CanHandler::start() {
+    if (m_running) { // If the handler is already running, return true
+        return true;
+    }
+
+    if (open_can(m_filepath.c_str()) != 0) { // opens the can file and If there was an error opening the CAN file, print an error message and return false
+        cerr << "Error while opening the CAN fiel: " << m_filepath << endl;
+        return false;
+    }
+
+    m_running = true;
+    m_receiverThread = thread(&CanHandler::receiveLoop, this); // Start the receiver thread to run the receiveLoop function
+
+    return true;
+
+}
+
+void CanHandler::stop() {
+    if (!m_running) {
+        return;
+    }
+
+    m_running = false;
+    m_condVar.notify_all(); // Notify the receiver thread to wake up and exit
+
+    if (m_receiverThread.joinable()) {
+        m_receiverThread.join();
+    }
+
+    close_can();
+}
+
+void CanHandler::receiveLoop() { 
+    char buffer[MAX_CAN_MESSAGE_SIZE]; // Buffer to hold incoming CAN messages
+
+    while (m_running) {
+        int bytes_read = can_receive(buffer);
+
+        if (bytes_read > 0){
+            string msg(buffer);
+            // cout << "Received CAN message: " << msg << endl;
+            lock_guard<mutex> lock(m_mutex);   // Lock the mutex to safely access the message queue
+            m_messageQueue.push(msg); // Add the received message to the queue
+            m_condVar.notify_one(); // Notify one waiting thread that a new message is available
+        }
+    }
+}
+
+bool CanHandler::getMessage(string& out_msg) {
+    unique_lock<mutex> lock(m_mutex); // Lock the mutex to safely access the message queue
+
+    m_condVar.wait(lock, [this]() { return !m_messageQueue.empty() || !m_running; }); // Wait until there is a message in the queue or the handler is stopped
+
+    if (!m_running && m_messageQueue.empty()) { 
+        return false;
+    }
+    
+    out_msg = m_messageQueue.front(); // Get the front message from the queue
+    m_messageQueue.pop(); // Remove the message from the queue
+    
+    return true;
+}

--- a/can_handler.h
+++ b/can_handler.h
@@ -1,0 +1,40 @@
+#ifndef CAN_HANDLER_H
+#define CAN_HANDLER_H
+
+#include <string>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+#include <atomic>
+
+using namespace std;
+
+extern "C"{
+    #include "fake_receiver.h"
+}
+
+class CanHandler {
+public:
+    CanHandler(const string& filepath); // Constructor to initialize the CAN handler with the given file path
+    ~CanHandler(); // Destructor to clean up resources
+
+    bool start(); // Start the CAN handler and begin receiving messages
+    void stop(); // Stop the CAN handler and clean up resources
+
+    bool getMessage(string& out_msg); // Retrieve a message from the queue, returns true if a message was retrieved, false if the queue is empty
+
+private:
+    void receiveLoop(); // The main loop that runs in a separate thread to receive messages from the CAN bus and add them to the queue
+
+    string m_filepath;
+    thread m_receiverThread;
+    
+    queue<string> m_messageQueue;
+    mutex m_mutex;
+    condition_variable m_condVar;
+
+    atomic<bool> m_running;
+};
+
+#endif


### PR DESCRIPTION
# Purpose
The purpose of this PR is to implement a thread-safe CAN message receiver. It decouples the raw CAN reading process from the main application logic using multithreading.

# Overview
- Created the `CanHandler` class to manage the CAN interface.
- Implemented a dedicated background thread (`receiveLoop`) that continuously reads from the `fake_receiver` C library.
- Added a thread-safe `queue` protected by a `mutex` and a `condition_variable` to allow safe producer-consumer communication between the receiver thread and the main thread.
- Fixed a bug regarding garbage characters at the end of the CAN string by specifying the exact `bytes_read` buffer size.

# Guidance
1. **`can_handler.h`**: Start here to review the class architecture, the threading variables, and the mutex/condition variable setup.
2. **`can_handler.cpp`**: Review the `start()` and `stop()` lifecycle methods, then focus on the synchronization logic in `receiveLoop()` (producer) and `getMessage()` (consumer).
3. **`CMakeLists.txt`**: Added the new source files.

Closes #1